### PR TITLE
Update README and app.rb to include recent memos count configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 - [Development](#development)
 - [Run it](#run-it)
 - [Follow-up: Inspiration, Knowledge](#follow-up-inspiration-knowledge)
-    - [Tantiny](#tantiny)
+    - [SQLite FTS5](#sqlite-fts5)
     - [Rails Multi-Model Search](#rails-multi-model-search)
 
 ---
@@ -207,6 +207,7 @@ services:
     environment:
       - USERNAME=yourusername # REPLACE THIS WITH YOUR VPS user's USERNAME
       - DATABASE_TYPE=file # Optional: use 'file' for persistent search index
+      - DEFAULT_RECENT_MEMOS_COUNT=25 # Optional: number of recent memos to show on homepage
     image: ghcr.io/simonneutert/labradorite-notebook:v0.2.0
     # ports:
     #  - 9292:9292

--- a/app.rb
+++ b/app.rb
@@ -235,7 +235,10 @@ class App < Roda
 
       # TODO: extract to controller
       r.is do
-        n_files = Config::Constants::Search::DEFAULT_RECENT_MEMOS_COUNT
+        n_files = ENV.fetch(
+          'DEFAULT_RECENT_MEMOS_COUNT',
+          Config::Constants::Search::DEFAULT_RECENT_MEMOS_COUNT
+        ).to_i
         r.etag(r.session['last_file_scan'])
 
         files = FileOperations::FilesSortByLatestModified.new.latest_n_memos_by_file_modified(n_files)


### PR DESCRIPTION
This pull request updates how the number of recent memos shown on the homepage is configured, making it easier to customize via environment variables. Additionally, it updates documentation to reflect the new search backend and configuration options.

Configuration improvements:

* The code in `app.rb` now fetches the number of recent memos to display from the `DEFAULT_RECENT_MEMOS_COUNT` environment variable, falling back to the default constant if not set. This makes it easier to adjust this setting without code changes.

Documentation updates:

* The `README.md` instructions for the Docker service now mention the new `DEFAULT_RECENT_MEMOS_COUNT` environment variable, explaining how to set the number of recent memos shown on the homepage.
* The search backend reference in the documentation has been updated from "Tantiny" to "SQLite FTS5" for accuracy.